### PR TITLE
fix production url connection

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -9,8 +9,8 @@ const config = require(`${__dirname}/../config/config.js`)[env];
 const db = {};
 
 let sequelize;
-if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable]);
+if (config.url) {
+  sequelize = new Sequelize(config.url, config);
 } else {
   sequelize = new Sequelize(
     config.database, config.username, config.password, config


### PR DESCRIPTION
## Description
 - Set Sequelize to use `url` for connection if set.